### PR TITLE
Initialize Node project with basic server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,26 @@ AI支持的创新项目发布系统 ( Innovation Project Knowledge Base ), 支�
 ## 页面 (react)
  - 用户登录界面  ( Login Page )
  - 项目搜索分页  ( A project search with preview: project title + snapshot )
- - 项目浏览/编辑分页
-    - 与 Agent和其他用户聊天的侧边栏 ( Agent and other user who have access to resource )
-    - 项目的每个阶段都有需要确认完成的里程碑 ( A markdown document viewer/editor markdown with sharing + milestone)
+   - 项目浏览/编辑分页
+      - 与 Agent和其他用户聊天的侧边栏 ( Agent and other users who have access to the resource )
+      - 项目的每个阶段都有需要确认完成的里程碑 ( A markdown document viewer/editor with sharing + milestones )
  - 用户资料库
     - 用户的资料空间，包括视频（上传后转lts），图片，文件等 (生成链接后，可以在项目里使用）
+
+## Development
+
+This repository includes a minimal Node.js server implementation. To start the server run:
+
+```bash
+npm start
+```
+
+The server will respond with "Hello from IdeaPortal" on port 3000.
+
+To execute the built-in tests run:
+
+```bash
+npm test
+```
+
+These tests use Node's built-in test runner and require no additional dependencies.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ideaportal-project",
+  "version": "0.1.0",
+  "description": "Innovation Project Knowledge Base skeleton",
+  "type": "module",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "NODE_ENV=test node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,17 @@
+import http from 'node:http';
+
+const PORT = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('Hello from IdeaPortal');
+});
+
+if (process.env.NODE_ENV !== 'test') {
+  server.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
+
+export default server;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import server from '../src/server.js';
+
+// Start the server on an ephemeral port before each test
+function startServer() {
+  return new Promise((resolve) => {
+    server.listen(0, () => resolve(server.address().port));
+  });
+}
+
+// Simple helper to fetch from the server
+function fetch(port, path = '/') {
+  return new Promise((resolve) => {
+    http.get({ host: 'localhost', port, path }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => resolve({ status: res.statusCode, data }));
+    });
+  });
+}
+
+test('GET / returns hello message', async (t) => {
+  const port = await startServer();
+  t.after(() => server.close());
+  const res = await fetch(port);
+  assert.equal(res.status, 200);
+  assert.equal(res.data, 'Hello from IdeaPortal');
+});


### PR DESCRIPTION
## Summary
- set up `package.json`
- add a basic Node.js HTTP server
- document dev workflow in README
- provide a simple test using Node's built-in test runner

## Testing
- `npm test`